### PR TITLE
Add first version of a rudimentary test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+project(onnxruntime_test)
+cmake_minimum_required(VERSION 3.14.0 FATAL_ERROR)
+cmake_policy(VERSION 3.14...3.23)
+
+# Define compiler on macosx to avoid problems when comparing to compilers
+# used for FairSoft/FairRoot compilation
+if(APPLE)
+  if(NOT DEFINED CMAKE_C_COMPILER)
+    set(CMAKE_C_COMPILER clang)
+  endif()
+  if(NOT DEFINED CMAKE_CXX_COMPILER)
+    set(CMAKE_CXX_COMPILER clang++)
+  endif()
+endif()
+
+# Default CMake settings
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if (NOT DEFINED ONNXPATH)
+  message(FATAL_ERROR "Please pass the path to the onnxruntime installation as -DONNXPATH")
+endif()
+
+list(PREPEND CMAKE_PREFIX_PATH ${ONNXPATH})
+message("CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}")
+find_package(ONNXRuntime CONFIG REQUIRED)
+
+get_target_property(bla ONNXRuntime::ONNXRuntime IMPORTED_LOCATION)
+message("IMPORTED_LOCATION: ${bla}")
+
+get_target_property(bla ONNXRuntime::ONNXRuntime INTERFACE_INCLUDE_DIRECTORIES)
+message("INTERFACE_INCLUDE_DIRECTORIES: ${bla}")
+
+add_executable(Inference_cnn Inference_cnn.cxx)
+target_link_libraries(Inference_cnn ONNXRuntime::ONNXRuntime)
+
+add_executable(Inference_xgb Inference_xgb.cxx)
+target_link_libraries(Inference_xgb ONNXRuntime::ONNXRuntime)
+

--- a/Inference_cnn.cxx
+++ b/Inference_cnn.cxx
@@ -1,0 +1,36 @@
+#include <iostream>
+#include "onnxruntime/core/session/onnxruntime_cxx_api.h"
+
+int main(){
+    
+    Ort::Env env{OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING, "mnist_cnn"};
+    Ort::Session session(env, "./mnist_cnn.onnx", Ort::SessionOptions(nullptr));
+
+    const char* input_names[] = {"input_1"};
+    const char* output_names[] = {"dense_1"};
+    std::array<float, 28*28> input_image{};
+    input_image.fill(0.2);
+    std::array<float, 10> results{};
+    std::array<int64_t, 4> input_shape{1, 28, 28, 1};
+    std::array<int64_t, 2> output_shape{1, 10};
+
+    auto allocator_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(allocator_info, input_image.data(), input_image.size(), input_shape.data(), input_shape.size());
+    
+    auto output_tensor = session.Run(Ort::RunOptions{nullptr}, input_names, &input_tensor, 1, output_names, 1);
+    float* intarr = output_tensor.front().GetTensorMutableData<float>();
+    std::vector<float> output_tensor_values {intarr, intarr + 10};
+    float result;
+    for(int i{}; i < output_tensor_values.size(); i++){
+        std::cout << output_tensor_values[i] << std::endl;
+        result += output_tensor_values[i];
+    }
+    std::cout << result << std::endl;
+    if ( 0.999999 < result && result < 1.000001 && 10 == output_tensor_values.size() ) {
+      return 0;
+    }
+    else {
+      return 1;
+    }
+
+}

--- a/Inference_xgb.cxx
+++ b/Inference_xgb.cxx
@@ -1,0 +1,29 @@
+#include <iostream>
+#include "onnxruntime/core/session/onnxruntime_cxx_api.h"
+
+int main(){
+    
+    Ort::Env env{OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING, "xgb"};
+    Ort::Session session(env, "./xgboost_boston.onnx", Ort::SessionOptions(nullptr));
+
+    const char* input_names[] = {"float_input"};
+    const char* output_names[] = {"variable"};
+    std::array<float, 13> input{};
+    input.fill(0.2);
+    std::array<float, 1> results{};
+    std::array<int64_t, 2> input_shape{1, 13};
+    std::array<int64_t, 2> output_shape{1, 1};
+
+    auto allocator_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(allocator_info, input.data(), input.size(), input_shape.data(), input_shape.size());
+    
+    auto output_tensor = session.Run(Ort::RunOptions{nullptr}, input_names, &input_tensor, 1, output_names, 1);
+    float* intarr = output_tensor.front().GetTensorMutableData<float>();
+    std::vector<float> output_tensor_values {intarr, intarr+1};
+    for(int i{}; i < output_tensor_values.size(); i++){
+        std::cout << output_tensor_values[i] << std::endl;
+    }
+    
+    return 0;
+
+}


### PR DESCRIPTION
The two source files are used to check if the compiled onnxruntime can be used and produce the correct results.
The Interference_cnn should return 10 values which shoulkd sum up to a probability of one. These information si alreday checked at the end of the function and the return values are choosen accordingly. This test can be used to check if the onnxruntime installation works as expected.
The result of the second test is currently not understood and I have asked for more information from the developer of the two tests.